### PR TITLE
Add singleton lock to prevent concurrent Spark Job Definition runs

### DIFF
--- a/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/Libs/singleton_lock.py
+++ b/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/Libs/singleton_lock.py
@@ -7,7 +7,9 @@ Spark Job Definition in Microsoft Fabric.
 
 import json
 import logging
-from datetime import datetime, timezone
+import time
+import uuid
+from datetime import datetime, timezone, timedelta
 
 import notebookutils
 
@@ -17,30 +19,61 @@ logger = logging.getLogger(__name__)
 class SingletonJobLock:
     """
     Distributed lock mechanism to prevent concurrent runs of the Spark Job Definition.
-    Uses a lock file in OneLake to ensure only one instance runs at a time.
+    Uses atomic file creation in OneLake to ensure only one instance runs at a time.
+    Includes heartbeat mechanism to detect and recover from stale locks.
     """
+    
+    # How often the heartbeat should be updated (seconds)
+    HEARTBEAT_INTERVAL = 60
+    # Lock is considered stale if heartbeat is older than this (seconds)
+    STALE_THRESHOLD = 300  # 5 minutes
     
     def __init__(self, lock_path: str, job_name: str = "stream_bronze_and_silver"):
         self.lock_path = lock_path
         self.job_name = job_name
         self.lock_acquired = False
+        self.instance_id = str(uuid.uuid4())
+        self._heartbeat_thread = None
+        self._stop_heartbeat = False
         
+    def _file_exists(self) -> bool:
+        """Check if lock file exists."""
+        try:
+            return notebookutils.fs.exists(self.lock_path)
+        except Exception as e:
+            logger.warning(f"Failed to check if lock file exists: {e}")
+            # Try alternative method - attempt to get file info
+            try:
+                notebookutils.fs.head(self.lock_path, max_bytes=1)
+                return True
+            except Exception:
+                return False
+
     def _read_lock_file(self) -> dict | None:
         """Read existing lock file if it exists."""
         try:
-            content = notebookutils.fs.head(self.lock_path, maxBytes=4096)
+            content = notebookutils.fs.head(self.lock_path, max_bytes=4096)
+            logger.debug(f"Lock file content: {content}")
             return json.loads(content)
-        except Exception:
+        except json.JSONDecodeError as e:
+            logger.error(f"Lock file exists but contains invalid JSON: {e}")
+            return None
+        except Exception as e:
+            logger.debug(f"Could not read lock file: {e}")
             return None
     
-    def _write_lock_file(self, lock_info: dict) -> bool:
+    def _write_lock_file(self, lock_info: dict, overwrite: bool = False) -> bool:
         """Write lock file with job information."""
         try:
             content = json.dumps(lock_info, indent=2)
-            notebookutils.fs.put(self.lock_path, content, overwrite=True)
+            notebookutils.fs.put(self.lock_path, content, overwrite=overwrite)
             return True
         except Exception as e:
-            logger.error(f"Failed to write lock file: {e}")
+            error_msg = str(e).lower()
+            if "exists" in error_msg or "already" in error_msg:
+                logger.debug(f"Lock file already exists: {e}")
+            else:
+                logger.error(f"Failed to write lock file: {e}")
             return False
     
     def _delete_lock_file(self) -> bool:
@@ -51,54 +84,179 @@ class SingletonJobLock:
         except Exception as e:
             logger.warning(f"Failed to delete lock file: {e}")
             return False
-    
-    def acquire(self) -> bool:
-        """
-        Attempt to acquire the lock.
-        Returns True if lock was acquired, False if another instance is running.
-        """
-        existing_lock = self._read_lock_file()
+
+    def _is_lock_stale(self, lock_info: dict) -> bool:
+        """Check if an existing lock is stale based on heartbeat timestamp."""
+        heartbeat_str = lock_info.get('heartbeat')
+        if not heartbeat_str:
+            # Old lock format without heartbeat - check started_at instead
+            heartbeat_str = lock_info.get('started_at')
         
-        if existing_lock:
-            logger.error("=" * 80)
-            logger.error("LOCK ACQUISITION FAILED - Another instance is already running!")
-            logger.error("=" * 80)
-            logger.error(f"  Job Name: {existing_lock.get('job_name', 'unknown')}")
-            logger.error(f"  Started At: {existing_lock.get('started_at', 'unknown')}")
-            logger.error(f"  Activity ID: {existing_lock.get('activity_id', 'unknown')}")
-            logger.error(f"  Livy ID: {existing_lock.get('livy_id', 'unknown')}")
-            logger.error("=" * 80)
-            logger.error("This job will exit to prevent concurrent streaming operations.")
-            logger.error("To force a new run, manually delete the lock file at:")
-            logger.error(f"  {self.lock_path}")
-            logger.error("=" * 80)
-            return False
-        
-        # Create lock with current job info
+        if not heartbeat_str:
+            # No timestamp at all - consider stale
+            return True
+            
+        try:
+            heartbeat_time = datetime.fromisoformat(heartbeat_str.replace('Z', '+00:00'))
+            age = (datetime.now(timezone.utc) - heartbeat_time).total_seconds()
+            is_stale = age > self.STALE_THRESHOLD
+            if is_stale:
+                logger.info(f"Lock is stale (last heartbeat: {age:.0f}s ago, threshold: {self.STALE_THRESHOLD}s)")
+            return is_stale
+        except Exception as e:
+            logger.warning(f"Failed to parse heartbeat timestamp: {e}")
+            return True
+
+    def _log_lock_holder(self, lock_info: dict):
+        """Log information about the current lock holder."""
+        logger.error("=" * 80)
+        logger.error("LOCK ACQUISITION FAILED - Another instance is already running!")
+        logger.error("=" * 80)
+        logger.error(f"  Job Name: {lock_info.get('job_name', 'unknown')}")
+        logger.error(f"  Started At: {lock_info.get('started_at', 'unknown')}")
+        logger.error(f"  Last Heartbeat: {lock_info.get('heartbeat', 'unknown')}")
+        logger.error(f"  Activity ID: {lock_info.get('activity_id', 'unknown')}")
+        logger.error(f"  Livy ID: {lock_info.get('livy_id', 'unknown')}")
+        logger.error(f"  Instance ID: {lock_info.get('instance_id', 'unknown')}")
+        logger.error("=" * 80)
+        logger.error("This job will exit to prevent concurrent streaming operations.")
+        logger.error("To force a new run, manually delete the lock file at:")
+        logger.error(f"  {self.lock_path}")
+        logger.error("=" * 80)
+
+    def _create_lock_info(self) -> dict:
+        """Create lock info dictionary with current job details."""
         context = notebookutils.runtime.context
-        lock_info = {
+        now = datetime.now(timezone.utc).isoformat()
+        return {
             "job_name": self.job_name,
-            "started_at": datetime.now(timezone.utc).isoformat(),
+            "started_at": now,
+            "heartbeat": now,
             "activity_id": context.get('activityId', 'unknown'),
             "livy_id": context.get('livyId', 'unknown'),
             "workspace_id": context.get('currentWorkspaceId', 'unknown'),
+            "instance_id": self.instance_id,
         }
+
+    def _start_heartbeat(self):
+        """Start background thread to update heartbeat periodically."""
+        import threading
         
-        if self._write_lock_file(lock_info):
-            self.lock_acquired = True
-            logger.info("=" * 80)
-            logger.info("LOCK ACQUIRED - This is the only running instance")
-            logger.info(f"  Lock file: {self.lock_path}")
-            logger.info("=" * 80)
-            return True
+        def heartbeat_loop():
+            while not self._stop_heartbeat:
+                time.sleep(self.HEARTBEAT_INTERVAL)
+                if self._stop_heartbeat:
+                    break
+                self._update_heartbeat()
         
-        return False
+        self._stop_heartbeat = False
+        self._heartbeat_thread = threading.Thread(target=heartbeat_loop, daemon=True)
+        self._heartbeat_thread.start()
+        logger.info(f"Heartbeat thread started (interval: {self.HEARTBEAT_INTERVAL}s)")
+
+    def _stop_heartbeat_thread(self):
+        """Stop the heartbeat background thread."""
+        self._stop_heartbeat = True
+        if self._heartbeat_thread:
+            self._heartbeat_thread.join(timeout=5)
+            self._heartbeat_thread = None
+
+    def _update_heartbeat(self):
+        """Update the heartbeat timestamp in the lock file."""
+        try:
+            lock_info = self._read_lock_file()
+            if lock_info and lock_info.get('instance_id') == self.instance_id:
+                lock_info['heartbeat'] = datetime.now(timezone.utc).isoformat()
+                self._write_lock_file(lock_info, overwrite=True)
+                logger.debug("Heartbeat updated")
+            else:
+                logger.warning("Lock ownership lost - stopping heartbeat")
+                self._stop_heartbeat = True
+        except Exception as e:
+            logger.warning(f"Failed to update heartbeat: {e}")
+    
+    def acquire(self) -> bool:
+        """
+        Attempt to acquire the lock using atomic file creation.
+        Handles stale locks from crashed/terminated jobs.
+        Returns True if lock was acquired, False if another instance is running.
+        """
+        lock_info = self._create_lock_info()
+        
+        # First check if lock file already exists
+        if self._file_exists():
+            logger.info("Lock file exists, checking if stale...")
+            existing_lock = self._read_lock_file()
+            
+            # Determine if we should attempt takeover
+            should_takeover = False
+            if not existing_lock:
+                # File exists but unreadable/invalid - treat as corrupted
+                logger.warning("Lock file exists but couldn't parse it - treating as corrupted")
+                should_takeover = True
+            elif self._is_lock_stale(existing_lock):
+                logger.warning("=" * 80)
+                logger.warning("STALE LOCK DETECTED - Taking over from crashed/terminated job")
+                logger.warning(f"  Previous holder: {existing_lock.get('instance_id', 'unknown')}")
+                logger.warning(f"  Previous start: {existing_lock.get('started_at', 'unknown')}")
+                logger.warning(f"  Last heartbeat: {existing_lock.get('heartbeat', 'unknown')}")
+                logger.warning("=" * 80)
+                should_takeover = True
+            else:
+                # Lock is held by an active job
+                self._log_lock_holder(existing_lock)
+                return False
+            
+            if should_takeover:
+                # Delete the stale lock first, then create new one atomically
+                logger.info("Deleting stale/corrupted lock file...")
+                self._delete_lock_file()
+                time.sleep(1)  # Brief delay to ensure deletion propagates
+        
+        # Try atomic creation (overwrite=False)
+        logger.info("Attempting to create lock file...")
+        if self._write_lock_file(lock_info, overwrite=False):
+            # Verify we own the lock
+            time.sleep(1)
+            verified = self._read_lock_file()
+            if verified and verified.get('instance_id') == self.instance_id:
+                self.lock_acquired = True
+                self._start_heartbeat()
+                logger.info("=" * 80)
+                logger.info("LOCK ACQUIRED - This is the only running instance")
+                logger.info(f"  Lock file: {self.lock_path}")
+                logger.info(f"  Instance ID: {self.instance_id}")
+                logger.info("=" * 80)
+                return True
+            elif verified:
+                # Another job got the lock
+                logger.error("Another instance acquired the lock during our attempt")
+                self._log_lock_holder(verified)
+                return False
+            else:
+                logger.error("Created lock file but couldn't verify ownership")
+                return False
+        else:
+            # Another job created the lock between our check and create
+            logger.error("Failed to create lock file - another instance may have acquired it")
+            existing_lock = self._read_lock_file()
+            if existing_lock:
+                self._log_lock_holder(existing_lock)
+            return False
     
     def release(self):
-        """Release the lock by deleting the lock file."""
+        """Release the lock by stopping heartbeat and deleting the lock file."""
+        self._stop_heartbeat_thread()
+        
         if self.lock_acquired:
-            if self._delete_lock_file():
-                logger.info("Lock released successfully")
-                self.lock_acquired = False
+            # Verify we still own the lock before deleting
+            current_lock = self._read_lock_file()
+            if current_lock and current_lock.get('instance_id') == self.instance_id:
+                if self._delete_lock_file():
+                    logger.info("Lock released successfully")
+                    self.lock_acquired = False
+                else:
+                    logger.warning("Failed to release lock - manual cleanup may be required")
             else:
-                logger.warning("Failed to release lock - manual cleanup may be required")
+                logger.warning("Lock ownership changed - not releasing")
+                self.lock_acquired = False

--- a/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/Libs/singleton_lock.py
+++ b/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/Libs/singleton_lock.py
@@ -1,0 +1,104 @@
+"""
+Singleton Lock for Spark Job Definition
+
+Provides a distributed lock mechanism to prevent concurrent runs of the same
+Spark Job Definition in Microsoft Fabric.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+import notebookutils
+
+logger = logging.getLogger(__name__)
+
+
+class SingletonJobLock:
+    """
+    Distributed lock mechanism to prevent concurrent runs of the Spark Job Definition.
+    Uses a lock file in OneLake to ensure only one instance runs at a time.
+    """
+    
+    def __init__(self, lock_path: str, job_name: str = "stream_bronze_and_silver"):
+        self.lock_path = lock_path
+        self.job_name = job_name
+        self.lock_acquired = False
+        
+    def _read_lock_file(self) -> dict | None:
+        """Read existing lock file if it exists."""
+        try:
+            content = notebookutils.fs.head(self.lock_path, maxBytes=4096)
+            return json.loads(content)
+        except Exception:
+            return None
+    
+    def _write_lock_file(self, lock_info: dict) -> bool:
+        """Write lock file with job information."""
+        try:
+            content = json.dumps(lock_info, indent=2)
+            notebookutils.fs.put(self.lock_path, content, overwrite=True)
+            return True
+        except Exception as e:
+            logger.error(f"Failed to write lock file: {e}")
+            return False
+    
+    def _delete_lock_file(self) -> bool:
+        """Delete the lock file."""
+        try:
+            notebookutils.fs.rm(self.lock_path, recurse=False)
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to delete lock file: {e}")
+            return False
+    
+    def acquire(self) -> bool:
+        """
+        Attempt to acquire the lock.
+        Returns True if lock was acquired, False if another instance is running.
+        """
+        existing_lock = self._read_lock_file()
+        
+        if existing_lock:
+            logger.error("=" * 80)
+            logger.error("LOCK ACQUISITION FAILED - Another instance is already running!")
+            logger.error("=" * 80)
+            logger.error(f"  Job Name: {existing_lock.get('job_name', 'unknown')}")
+            logger.error(f"  Started At: {existing_lock.get('started_at', 'unknown')}")
+            logger.error(f"  Activity ID: {existing_lock.get('activity_id', 'unknown')}")
+            logger.error(f"  Livy ID: {existing_lock.get('livy_id', 'unknown')}")
+            logger.error("=" * 80)
+            logger.error("This job will exit to prevent concurrent streaming operations.")
+            logger.error("To force a new run, manually delete the lock file at:")
+            logger.error(f"  {self.lock_path}")
+            logger.error("=" * 80)
+            return False
+        
+        # Create lock with current job info
+        context = notebookutils.runtime.context
+        lock_info = {
+            "job_name": self.job_name,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "activity_id": context.get('activityId', 'unknown'),
+            "livy_id": context.get('livyId', 'unknown'),
+            "workspace_id": context.get('currentWorkspaceId', 'unknown'),
+        }
+        
+        if self._write_lock_file(lock_info):
+            self.lock_acquired = True
+            logger.info("=" * 80)
+            logger.info("LOCK ACQUIRED - This is the only running instance")
+            logger.info(f"  Lock file: {self.lock_path}")
+            logger.info("=" * 80)
+            return True
+        
+        return False
+    
+    def release(self):
+        """Release the lock by deleting the lock file."""
+        if self.lock_acquired:
+            if self._delete_lock_file():
+                logger.info("Lock released successfully")
+                self.lock_acquired = False
+            else:
+                logger.warning("Failed to release lock - manual cleanup may be required")

--- a/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/Main/main.py
+++ b/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/Main/main.py
@@ -16,7 +16,7 @@ DEPLOYMENT INSTRUCTIONS:
    
 3. Create Spark Job Definition:
    - Main file: Upload this file (main.py)
-   - Reference files: Upload pipeline_config.py
+   - Reference files: Upload pipeline_config.py, singleton_lock.py
    - Environment: Select environment with arcflow wheel
    - Reference Lakehouse: Select the Lakehouse where data should be written
    
@@ -39,9 +39,11 @@ from lakegen.generators.mcmillan_industrial_group import McMillanDataGen
 import notebookutils
 from pyspark.sql import SparkSession
 from pipeline_config import tables
+from singleton_lock import SingletonJobLock
 
 import logging
 import sys
+import atexit
 
 # Configure logging
 logging.basicConfig(
@@ -70,12 +72,25 @@ if __name__ == "__main__":
     spark_context = spark.sparkContext
     spark_context.setLogLevel("ERROR")
 
-    logger.info("=" * 80)
-    logger.info("Starting LakeGen: McMillanDataGen")
-    logger.info("=" * 80)
+    # Step 1.5: Acquire singleton lock to prevent concurrent runs
     default_workspace_id = notebookutils.runtime.context['currentWorkspaceId']
     default_lakehouse_id = notebookutils.runtime.context['defaultLakehouseId']
     onelake_endpoint = spark.sparkContext._jsc.hadoopConfiguration().get("trident.onelake.endpoint").split('//')[1]
+    
+    lock_path = f"abfss://{default_workspace_id}@{onelake_endpoint}/{default_lakehouse_id}/Files/.locks/stream_bronze_and_silver.lock"
+    job_lock = SingletonJobLock(lock_path=lock_path)
+    
+    if not job_lock.acquire():
+        logger.error("Exiting due to concurrent run prevention")
+        spark.stop()
+        sys.exit(1)
+    
+    # Register cleanup handler to release lock on exit
+    atexit.register(job_lock.release)
+
+    logger.info("=" * 80)
+    logger.info("Starting LakeGen: McMillanDataGen")
+    logger.info("=" * 80)
     target_folder_uri=f"abfss://{default_workspace_id}@{onelake_endpoint}/{default_lakehouse_id}/Files/landing/"
 
     logger.info(target_folder_uri)
@@ -125,4 +140,8 @@ if __name__ == "__main__":
 
     # Step 3: Run full pipeline
     logger.info("Starting full ELT pipeline...")
-    controller.run_full_pipeline(zones=['bronze', 'silver'])
+    try:
+        controller.run_full_pipeline(zones=['bronze', 'silver'])
+    finally:
+        # Ensure lock is released even if pipeline fails
+        job_lock.release()

--- a/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/SparkJobDefinitionV1.json
+++ b/workspace/analytics-roadshow-lab/stream_bronze_and_silver.SparkJobDefinition/SparkJobDefinitionV1.json
@@ -6,7 +6,8 @@
   "retryPolicy": null,
   "commandLineArguments": "",
   "additionalLibraryUris": [
-    "pipeline_config.py"
+    "pipeline_config.py",
+    "singleton_lock.py"
   ],
   "language": "Python",
   "environmentArtifactId": "915772e2-8dba-be8f-4ecd-c2f82a8afc65"


### PR DESCRIPTION
## Summary
   Prevents multiple concurrent executions of the `stream_bronze_and_silver` Spark Job Definition, which was causing capacity exhaustion and streaming errors.

 ## Changes
   - **New file:** `singleton_lock.py` - Distributed lock mechanism using OneLake
   - **Modified:** `main.py` - Integrates lock acquisition at startup
   - **Modified:** `SparkJobDefinitionV1.json` - Registers new library file

 ## How it works
   - Creates a lock file in the Lakehouse (`Files/.locks/stream_bronze_and_silver.lock`) before processing starts
   - Uses atomic file creation to ensure only one instance acquires the lock
   - Maintains a heartbeat (updated every 60s) to indicate the job is still alive
   - Automatically recovers stale locks from crashed/terminated jobs after 5 minutes
   - Duplicate runs fail fast with `exit(1)` to avoid wasting compute resources

 ## Testing
   - Verified concurrent job launches: only first job runs, others exit immediately
   - Verified stale lock recovery: after stopping a job and waiting >5 minutes, new job successfully takes over